### PR TITLE
WebClient 오류에서 시작하는 Raw Type과 ParameterizedTypeReference

### DIFF
--- a/_ko/2025-05-16-raw-type-and-paramterized-type.markdown
+++ b/_ko/2025-05-16-raw-type-and-paramterized-type.markdown
@@ -1,0 +1,11 @@
+---
+title: Raw Type과 ParameterizedTypeReference
+lang: ko
+layout: post
+---
+
+## 들어가며
+
+- 타입 안전성을 보장하지 않는 Raw Type과 이를 해결하기 위한 ParameterizedTypeReference에 대해 알아보는 글입니다. 특히, Spring Boot에서 `WebClient`를 이용해 배열 형태로 response body를 받는 경우에 대하여 살펴보고, 이에서 단순히 `List.class`를 이용했을 때의 문제 상황에서 시작합니다.
+
+## Raw Type과 ParameterizedTypeReference

--- a/_ko/2025-05-16-raw-type-and-paramterized-type.markdown
+++ b/_ko/2025-05-16-raw-type-and-paramterized-type.markdown
@@ -6,6 +6,168 @@ layout: post
 
 ## 들어가며
 
-- 타입 안전성을 보장하지 않는 Raw Type과 이를 해결하기 위한 ParameterizedTypeReference에 대해 알아보는 글입니다. 특히, Spring Boot에서 `WebClient`를 이용해 배열 형태로 response body를 받는 경우에 대하여 살펴보고, 이에서 단순히 `List.class`를 이용했을 때의 문제 상황에서 시작합니다.
+- 타입 안전성을 보장하지 않는 Raw Type과 이를 해결하기 위한 ParameterizedTypeReference에 대해 알아보는 글입니다.
+- 특히, Spring Boot에서 `WebClient`를 이용해 배열 형태로 response body를 받는 경우에 대하여 살펴보고, 이에서 단순히 `List.class`를 이용했을 때의 문제 상황에서 시작합니다.
+- 최종 수정: 25/05/16
 
-## Raw Type과 ParameterizedTypeReference
+## Raw Type 이해하기
+
+Raw Type은 제네릭이 등장하기 전인 JDK 5.0 이전 버전과의 호환성을 위해 도입되었는데요. Raw Type은 Java에서 제네릭 클래스나 인터페이스에서 타입 아규먼트가 지정되어있지 않은 경우를 의미합니다.
+
+아래 예시를 보시면 이해가 쉬울 것입니다.
+
+```java
+// actual type argument passed
+List<String> list = new ArrayList<>();
+// raw type of List<T>
+List rawList = new ArrayList();
+```
+
+위에서 `List<String>`은 타입 아규먼트가 `String` 으로 지정된 제네릭 클래스이고, `List`는 타입 아규먼트가 지정되어있지 않은 Raw Type입니다. 코드를 통해서 두 `List` 타입의 차이를 확인해보겠습니다.
+
+### 코드 예시
+
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static class Box {
+        public int x = 10;
+        public int y = 20;
+
+        Box() {
+        }
+    }
+
+    public static void main(String[] args) {
+
+        // Parameterized Type (타입 안전)
+        List<String> parameterizedList = new ArrayList<>();
+        parameterizedList.add("Hello");
+        // parameterizedList.add(123); // 컴파일 오류! String만 허용
+
+        String str = parameterizedList.get(0);
+        System.out.println(str);
+
+        // Raw Type (타입 안전성 저하)
+        List rawList = new ArrayList(); // 컴파일러 경고 발생 가능성
+        rawList.add("World");
+        rawList.add(456); // 다른 타입의 객체도 추가 가능
+        rawList.add(new Box());
+
+        Object obj1 = rawList.get(0);
+        if (obj1 instanceof String) {
+            String item1Casted = (String) obj1;
+            System.out.println(item1Casted);
+        }
+
+        // Object obj2 = rawList.get(1);
+        // String item2Casted = (String) obj2; // 여기서 ClassCastException 발생!
+        // System.out.println(item2Casted);
+
+        Box box = (Box) rawList.get(2);
+        System.out.println(box.x);
+    }
+}
+```
+
+```
+출력 결과
+---
+Hello
+World
+10
+```
+
+`List<String>`은 `String` 타입이 아닌 요소가 들어가면 컴파일 오류가 발생하지만, `List`는 타입 아규먼트가 지정되어있지 않은 Raw Type이기 때문에 컴파일 오류가 발생하지 않습니다.
+
+또한, `List`는 타입 아규먼트가 지정되어있지 않기 때문에 다양한 타입의 객체를 저장할 수 있습니다. 위 예시에서도 `String`, `Integer`, `Box` 타입의 객체를 저장하고 있습니다.
+
+하지만 주석 처리 해둔 코드처럼 타입 아규먼트가 지정되어있지 않은 경우에는 기본적으로 `Object`로 처리하기 때문에, 형변환을 해줘야 합니다. 이렇게 형변환을 해주지 않으면 런타임 오류가 발생할 수 있습니다.
+
+즉, Raw Type은 타입 안전성을 보장하지 않습니다. 컴파일러 역시 Raw Type을 이용하면 unchecked 경고를 일으키기도 합니다.
+
+## WebClient와 함께 살펴보는 Raw Type
+
+```java
+public List<TftLeagueEntryResponse> getLeagueEntries(String puuid) {
+    return handleApiCall(
+            riotKorWebClient.get()
+                    .uri("/tft/league/v1/by-puuid/{puuid}", puuid)
+                    .retrieve()
+                    .accept(MediaType.APPLICATION_JSON)
+                    .bodyToMono(List.class),
+            "소환사의 TFT 리그 정보를 찾을 수 없습니다: " + puuid
+    );
+}
+```
+
+위 코드는 제가 직접 문제를 겪었던, Riot 계정의 TFT 리그 엔트리 정보를 찾는 메서드입니다. 이 메서드는 `WebClient`를 이용하여 웹 서비스에 요청을 보낸 뒤 응답을 `List<TftLeagueEntryResponse>` 타입으로 받습니다.
+
+Response Body는 아래와 같이 배열로 둘러 싸인 JSON으로 반환됩니다. 이 때, 배열 안에 들어가는 요소는 모두 `TftLeagueEntryResponse` 타입으로 변환되어야 합니다.
+
+```json
+[
+  {
+    "puuid": "puuid",
+    "leagueId": "leagueId",
+    "queueType": "RANKED_TFT",
+    "tier": "PLATINUM",
+    "rank": "II",
+    "summonerId": "summonerId",
+    "leaguePoints": 45,
+    "wins": 84,
+    "losses": 95,
+    "veteran": false,
+    "inactive": false,
+    "freshBlood": false,
+    "hotStreak": false
+  }
+]
+```
+
+위 테스트 코드에서 중요한 것은 바로 `bodyToMono(List.class)` 부분입니다. 이 부분은 제네릭 타입을 이용하여 타입 안전성을 보장하는 것이 아니라, Raw Type을 이용하기에 타입 안전성이 보장되지 않음을 예측할 수 있습니다. 응답 역시도 `List` 타입으로 받아오게 되듯이 말입니다.
+
+그렇다면 이제 테스트 코드를 통해 이를 확인해보겠습니다.
+
+### 테스트 코드를 통한 확인
+
+```java
+@Test
+void TFT_랭크_엔트리_실제API호출_테스트() throws InterruptedException {
+    // given
+    String gameName = "승상싱";
+    String tagLine = "KR1";
+
+    String puuid = riotAccountClient.getAccountInfo(gameName, tagLine).puuid();
+
+    // when
+    List<TftLeagueEntryResponse> response = tftApiClient.getLeagueEntries(puuid);
+
+    log.debug("puuid returned: {}", puuid);
+    log.debug(response.toString());
+
+    /*
+        에러 발생!
+    */
+    TftLeagueEntryResponse entry0 = (TftLeagueEntryResponse) response.get(0);
+
+    // then
+    assertNotNull(response);
+    assertThat(Objects.equals(entry0.puuid(), puuid));
+}
+```
+
+가장 처음 살펴보았던, `List rawList`와 같은 방식이라면 분명히 `entry0`은 `TftLeagueEntryResponse` 타입으로 변환되어야 합니다. 하지만 위 테스트 코드를 실행하면 `에러 발생!` 부분에서 `ClassCastException`이 발생하는 것을 확인할 수 있습니다.
+
+```
+java.lang.ClassCastException: class java.util.LinkedHashMap cannot be cast to class com.glennsyj.rivals.api.tft.model.TftLeagueEntryResponse (이하 생략)
+```
+
+이러한 에러는 왜 발생할까요? 해결 방안을 살펴보기 전에, 우선 `WebClient`가 어떻게 위 riot api 경로의 응답을 받아들이는지 그 구조를 살펴보겠습니다.
+
+### WebClient란?
+
+`WebClient`는 Spring WebFlux에서 제공하는 논블로킹, 리액티브 HTTP 클라이언트입니다. 동기 및 블로킹 방식의 RestTemplate의 대체로 사용가능하며, 추후 `RestClient`가 등장하기는 했지만, 추후 서비스가 복잡해질 것을 고려하여 `WebClient`를 택했습니다.

--- a/_ko/2025-05-16-raw-type-and-paramterized-type.markdown
+++ b/_ko/2025-05-16-raw-type-and-paramterized-type.markdown
@@ -340,3 +340,13 @@ Raw Type 때문에 JSON 객체가 의도한 DTO가 아닌 `LinkedHashMap`으로 
 결국, Raw Type의 사용은 가급적 지양하고, 제네릭 타입을 다룰 때는 `ParameterizedTypeReference`와 같이 타입 정보를 명확히 전달할 수 있는 방법을 이용할 필요가 있겠습니다.
 
 비록 `Mono`란 무엇인가에 대한 설명, 왜 `ParameterizedTypeReference`를 익명 클래스로 생성하는 가에 대한 바이트코드 분석은 다루지 못했지만, 이번 글은 여기에서 마치도록 하겠습니다.
+
+## References
+
+[https://docs.oracle.com/javase/tutorial/java/generics/rawTypes.html](https://docs.oracle.com/javase/tutorial/java/generics/rawTypes.html)
+
+[https://github.com/spring-projects/spring-framework/blob/main/spring-core/src/main/java/org/springframework/core/ParameterizedTypeReference.java](https://github.com/spring-projects/spring-framework/blob/main/spring-core/src/main/java/org/springframework/core/ParameterizedTypeReference.java)
+
+[https://developer.riotgames.com/apis](https://developer.riotgames.com/apis)
+
+[https://github.com/glenn-syj/rivals](https://github.com/glenn-syj/rivals)


### PR DESCRIPTION
## 개요

Spring WebClient에서 발생할 수 있는 Raw Type 관련 문제와 이를 해결하기 위한 ParameterizedTypeReference의 활용을 다룹니다. 외부 API(Riot API)를 WebClient로 이용하며 발생한 문제 상황에서 시작해, Raw Type에 기반한 에러와 ParameterizedTypeReference를 
분석합니다.

## 주요 내용

### 1. Raw Type의 문제점과 WebClient 오류 분석
-   Java Raw Type의 개념과 타입 안전성 저해 문제 설명
-   `WebClient`의 `bodyToMono()`에서 `List.class`와 같은 Raw Type 사용 시 발생하는 `ClassCastException` (JSON 객체가 `LinkedHashMap`으로 변환되는 현상) 분석
-   제네릭 타입 소거가 역직렬화 과정에 미치는 영향 설명

### 2. `ParameterizedTypeReference` 소개 및 원리
-   `ParameterizedTypeReference`의 등장 배경 및 역할 소개
-   익명 내부 클래스를 활용하여 런타임에 완전한 제네릭 타입 정보를 보존하는 원리 설명 (`findParameterizedTypeReferenceSubclass` 메서드 및 `type` 필드)
-   중첩된 제네릭 타입(예: `Map<String, List<String>>`) 처리 방식 예시

### 3. `WebClient`에서의 `ParameterizedTypeReference` 활용 및 문제 해결
-   기존 `bodyToMono(List.class)` 방식의 한계점 재확인
-   `bodyToMono(new ParameterizedTypeReference<List<DTO>>() {})`를 사용하여 `WebClient` 응답을 타입 안전하게 역직렬화하는 방법 제시
-   실제 코드 예시

## 기대 효과

-   Java Raw Type의 위험성과 제네릭 타입 소거의 영향을 명확히 이해
-   Spring `ParameterizedTypeReference`의 필요성과 내부 동작 원리
-   `WebClient` 사용 시 제네릭 컬렉션 타입의 응답 처리 방식
-   type-safe한 프로그래밍의 중요성 인지
